### PR TITLE
Strip out Cmdr-specific Latitude and Longitude from Location events

### DIFF
--- a/schemas/journal-v1.0.json
+++ b/schemas/journal-v1.0.json
@@ -59,7 +59,9 @@
                 "BoostUsed"         : { "$ref" : "#/definitions/disallowed" },
                 "FuelLevel"         : { "$ref" : "#/definitions/disallowed" },
                 "FuelUsed"          : { "$ref" : "#/definitions/disallowed" },
-                "JumpDist"          : { "$ref" : "#/definitions/disallowed" }
+                "JumpDist"          : { "$ref" : "#/definitions/disallowed" },
+                "Latitude"          : { "$ref" : "#/definitions/disallowed" },
+                "Longitude"         : { "$ref" : "#/definitions/disallowed" }
             },
             "patternProperties"     : {
                 "_Localised$"       : { "$ref" : "#/definitions/disallowed" }


### PR DESCRIPTION
If we're going to allow "Location" event messages (46f8616) we should ensure that Cmdr-specific data is stripped out.
