### PR TITLE
Add SystemAddress property for Scan events

### DIFF
--- a/schemas/journal-v1.0.json
+++ b/schemas/journal-v1.0.json
@@ -54,6 +54,10 @@
                     "maxItems"      : 3,
                     "description"   : "Must be added by the sender if not present in the journal event"
                 },
+                "SystemAddress": {
+                    "type"          : "number",
+                    "description"   : "Should be added by the sender if not present in the journal event"
+                },
 
                 "CockpitBreach"     : { "$ref" : "#/definitions/disallowed" },
                 "BoostUsed"         : { "$ref" : "#/definitions/disallowed" },


### PR DESCRIPTION
Not made mandatory to allow processing of historical E:D 2.x events.