### PR TITLE
Changed output to JSON format (use double quotes)

### DIFF
--- a/examples/Python 3.4/Client_Simple.py
+++ b/examples/Python 3.4/Client_Simple.py
@@ -36,8 +36,8 @@ def main():
                 __message   = zlib.decompress(__message)
                 __json      = simplejson.loads(__message)
                 
-                
-                print (__json)
+                # call dumps() to ensure double quotes in output
+                print(simplejson.dumps(__json))
                 sys.stdout.flush()
                 
         except zmq.ZMQError as e:


### PR DESCRIPTION
JSON uses double quotes and therefore the program should output a valid JSON instead of python strings (single quotes)