### PR TITLE
Add "horizons" boolean property and make "marketId" mandatory

### DIFF
--- a/schemas/commodity-v3.0.json
+++ b/schemas/commodity-v3.0.json
@@ -32,7 +32,7 @@
         "message": {
             "type"                  : "object",
             "additionalProperties"  : false,
-            "required"              : [ "systemName", "stationName", "timestamp", "commodities" ],
+            "required"              : [ "systemName", "stationName", "marketId", "timestamp", "commodities" ],
             "properties"            : {
                 "systemName": {
                     "type"      : "string",
@@ -43,7 +43,11 @@
                     "minLength" : 1
                 },                
                 "marketId": {
-                    "type"          : "number"
+                    "type"      : "number"
+                },
+                "horizons": {
+                    "type"      : "boolean",
+                    "description" : "Whether the sending Cmdr has a Horizons pass."
                 },
                 "timestamp": {
                     "type"      : "string",

--- a/schemas/outfitting-v2.0.json
+++ b/schemas/outfitting-v2.0.json
@@ -32,7 +32,7 @@
         "message": {
             "type"                  : "object",
             "additionalProperties"  : false,
-            "required"              : [ "systemName", "stationName", "timestamp", "modules" ],
+            "required"              : [ "systemName", "stationName", "marketId", "timestamp", "modules" ],
             "properties"            : {
                 "systemName": {
                     "type"      : "string",
@@ -43,7 +43,11 @@
                     "minLength" : 1
                 },                
                 "marketId": {
-                    "type"          : "number"
+                    "type"      : "number"
+                },
+                "horizons": {
+                    "type"      : "boolean",
+                    "description" : "Whether the sending Cmdr has a Horizons pass."
                 },
                 "timestamp": {
                     "type"      : "string",

--- a/schemas/shipyard-v2.0.json
+++ b/schemas/shipyard-v2.0.json
@@ -32,7 +32,7 @@
         "message": {
             "type"                  : "object",
             "additionalProperties"  : false,
-            "required"              : [ "systemName", "stationName", "timestamp", "ships" ],
+            "required"              : [ "systemName", "stationName", "marketId", "timestamp", "ships" ],
             "properties"            : {
                 "systemName": {
                     "type"      : "string",
@@ -44,6 +44,10 @@
                 },                
                 "marketId": {
                     "type"          : "number"
+                },
+                "horizons": {
+                    "type"      : "boolean",
+                    "description" : "Whether the sending Cmdr has a Horizons pass."
                 },
                 "timestamp": {
                     "type"      : "string",


### PR DESCRIPTION
"horizons" flag, if present, allows listener to factor in the fact that some expected commodities/modules/ships may be missing due to the sender not having a Horizons pass.

For PC/Steam users, senders can determine whether the user has a Horizons pass by looking at the "Horizons" property in the Journal "LoadGame" event.