### PR TITLE
Add "allowCobraMkIV" boolean property to shipyard message

### DIFF
--- a/schemas/shipyard-v2.0.json
+++ b/schemas/shipyard-v2.0.json
@@ -49,6 +49,10 @@
                     "type"          : "boolean",
                     "description"   : "Whether the sending Cmdr has a Horizons pass."
                 },
+                "allowCobraMkIV": {
+                    "type"          : "boolean",
+                    "description"   : "Whether the sending Cmdr can purchase the Cobra MkIV or not."
+                },
                 "timestamp": {
                     "type"          : "string",
                     "format"        : "date-time"

--- a/schemas/shipyard-v2.0.json
+++ b/schemas/shipyard-v2.0.json
@@ -35,23 +35,23 @@
             "required"              : [ "systemName", "stationName", "marketId", "timestamp", "ships" ],
             "properties"            : {
                 "systemName": {
-                    "type"      : "string",
-                    "minLength" : 1
+                    "type"          : "string",
+                    "minLength"     : 1
                 },
                 "stationName": {
-                    "type"      : "string",
-                    "minLength" : 1
+                    "type"          : "string",
+                    "minLength"     : 1
                 },                
                 "marketId": {
                     "type"          : "integer"
                 },
                 "horizons": {
-                    "type"      : "boolean",
-                    "description" : "Whether the sending Cmdr has a Horizons pass."
+                    "type"          : "boolean",
+                    "description"   : "Whether the sending Cmdr has a Horizons pass."
                 },
                 "timestamp": {
-                    "type"      : "string",
-                    "format"    : "date-time"
+                    "type"          : "string",
+                    "format"        : "date-time"
                 },
                 "ships": {
                     "type"          : "array",


### PR DESCRIPTION
Not all players can see/purchase the Cobra MkIV in their shipyard. This property makes it easier for listeners to decide what to do with their local shipyard if the only difference between is a missing Cobra MkIV.