### PR TITLE
Added 'CarrierJump' event

### DIFF
--- a/schemas/journal-v1.0.json
+++ b/schemas/journal-v1.0.json
@@ -40,7 +40,7 @@
                     "format"        : "date-time"
                 },
                 "event" : {
-                    "enum"          : [ "Docked", "FSDJump", "Scan", "Location", "SAASignalsFound" ]
+                    "enum"          : [ "Docked", "FSDJump", "Scan", "Location", "SAASignalsFound", "CarrierJump" ]
                 },
                 "StarSystem": {
                     "type"          : "string",
@@ -61,7 +61,7 @@
 
                 "Factions": {
                     "type"          : "array",
-                    "description"   : "Present in Location and FSDJump messages",
+                    "description"   : "Present in Location, FSDJump and CarrierJump messages",
                     "items" : {
                         "type"      : "object",
                         "properties": {


### PR DESCRIPTION
The `CarrierJump` event is equal to an `Location` event and is generated if one is docked at an fleetcarrier while the carrier is jumping (instead of an `FSDJump` event).