### PR TITLE
Added Go example

### DIFF
--- a/examples/Go/eddn.go
+++ b/examples/Go/eddn.go
@@ -1,0 +1,64 @@
+package main
+
+import (
+	"bytes"
+	"compress/zlib"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"gopkg.in/zeromq/goczmq.v4"
+)
+
+type EDDN struct {
+	SchemaRef string          `json:"$schemaRef"`
+	Header    EDDNHeader      `json:"header"`
+	Message   json.RawMessage `json:"message"`
+}
+type EDDNHeader struct {
+	UploaderID       string    `json:"uploaderID"`
+	SoftwareName     string    `json:"softwareName"`
+	SoftwareVersion  string    `json:"softwareVersion"`
+	GatewayTimestamp time.Time `json:"gatewayTimestamp"`
+}
+
+func main() {
+	channel := goczmq.NewSubChanneler("tcp://eddn.edcd.io:9500", "")
+	defer channel.Destroy()
+
+	run := true
+	for run {
+		select {
+		case rawMessage, ok := <-channel.RecvChan:
+			if !ok {
+				run = false
+				continue
+			}
+
+			message, err := decodeMessage(rawMessage[0])
+			if err != nil {
+				fmt.Println(err.Error())
+				run = false
+				continue
+			}
+
+			fmt.Println(message.SchemaRef, message.Header.SoftwareName)
+		}
+	}
+}
+
+func decodeMessage(rawMessage []byte) (*EDDN, error) {
+	r, err := zlib.NewReader(bytes.NewReader(rawMessage))
+	if err != nil {
+		return nil, err
+	}
+	defer r.Close()
+
+	var message EDDN
+	err = json.NewDecoder(r).Decode(&message)
+	if err != nil {
+		return nil, err
+	}
+
+	return &message, nil
+}

--- a/examples/Go/go.mod
+++ b/examples/Go/go.mod
@@ -1,0 +1,5 @@
+module github.com/EDSM-NET/EDDN
+
+go 1.14
+
+require gopkg.in/zeromq/goczmq.v4 v4.1.0

--- a/examples/Go/go.sum
+++ b/examples/Go/go.sum
@@ -1,0 +1,2 @@
+gopkg.in/zeromq/goczmq.v4 v4.1.0 h1:CE+FE81mGVs2aSlnbfLuS1oAwdcVywyMM2AC1g33imI=
+gopkg.in/zeromq/goczmq.v4 v4.1.0/go.mod h1:h4IlfePEYMpFdywGr5gAwKhBBj+hiBl/nF4VoSE4k+0=


### PR DESCRIPTION
Can be executed by using `go run .` in the `Go` example.

It uses channels for concurrent workload handling https://tour.golang.org/concurrency/2

And will print the the `$schemaRef` and `header.softwareName` to show how to access those information.